### PR TITLE
Allow for level=1 in gsd

### DIFF
--- a/pyDOE3/doe_gsd.py
+++ b/pyDOE3/doe_gsd.py
@@ -205,7 +205,7 @@ def _make_partitions(factor_levels, num_partitions):
 
         for num_levels in factor_levels:
             part = list()
-            for level_i in range(1, num_levels):
+            for level_i in range(1, num_levels + 1):
                 index = partition_i + (level_i - 1) * num_partitions
                 if index <= num_levels:
                     part.append(index)

--- a/pyDOE3/doe_gsd.py
+++ b/pyDOE3/doe_gsd.py
@@ -205,8 +205,8 @@ def _make_partitions(factor_levels, num_partitions):
 
         for num_levels in factor_levels:
             part = list()
-            for level_i in range(1, num_levels + 1):
-                index = partition_i + (level_i - 1) * num_partitions
+            for level_i in range(num_levels):
+                index = partition_i + level_i * num_partitions
                 if index <= num_levels:
                     part.append(index)
 

--- a/tests/test_gsd.py
+++ b/tests/test_gsd.py
@@ -37,3 +37,9 @@ class TestGsd(unittest.TestCase):
         expected = [[0, 1], [0, 3], [2, 1], [2, 3], [1, 0], [1, 2]]
         actual = gsd([3, 4], 2, n=2)[1]
         np.testing.assert_allclose(actual, expected)
+
+    def test_gsd4(self):
+        expected = [[0, 1, 0], [0, 3, 0], [2, 1, 0], [2, 3, 0], [1, 0, 0],
+                    [1, 2, 0]]
+        actual = gsd([3, 4, 1], 2, n=2)[1]
+        np.testing.assert_allclose(actual, expected)


### PR DESCRIPTION
Hello,

Thanks pyDOE3 team to keep this project alive !

I came accros a corner case when working with pyDOE3: I want to be able to generate `fullfact` or `gsd` plans with the same `levels` list. `fullfact` allows for level to be equal to 1 but this is not possible in gsd (it raises _ValueError: reduction too large compared to factor level_)

Of course when level=1 a corresponding column of 0 is expected as a result of fullfact or gsd.

I have updated here `_make_partitions` function to solve this issue.

Regards,
Laurent