### PR TITLE
Add Doehlert method

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ number of factors:
 - Response-Surface Designs
   - Box-Behnken (``bbdesign``)
   - Central-Composite (``ccdesign``)
+  - Doehlert Design (``doehlert_shell_design``, ``doehlert_simplex_design``)
 - Randomized Designs
   - Latin-Hypercube (``lhs``)
 - Taguchi Designs
@@ -74,6 +75,7 @@ References
 - [Plackett-Burman designs](http://en.wikipedia.org/wiki/Plackett-Burman_design)
 - [Box-Behnken designs](http://en.wikipedia.org/wiki/Box-Behnken_design)
 - [Central composite designs](http://en.wikipedia.org/wiki/Central_composite_design)
+- [Doehlert Design](https://academic.oup.com/jrsssc/article/19/3/231/6882590)
 - [Latin-Hypercube designs](http://en.wikipedia.org/wiki/Latin_hypercube_sampling)
 - [Taguchi designs](http://en.wikipedia.org/wiki/Taguchi_methods)
 - Surowiec, Izabella, Ludvig Vikström, Gustaf Hector, Erik Johansson,

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -47,6 +47,8 @@ number of factors:
 
   #. :ref:`Central-Composite <central_composite>` (``ccdesign``)
 
+  #. :ref:`Doehlert Design <doehlert_design>` (``doehlert_shell_design``, ``doehlert_simplex_design``)
+
 - :ref:`Randomized Designs <randomized>`
 
   #. :ref:`Latin-Hypercube <latin_hypercube>` (``lhs``)
@@ -83,7 +85,7 @@ Credits
 
 This code was originally published by the following individuals for use with
 Scilab:
-    
+
 - Copyright (C) 2012 - 2013 - Michael Baudin
 - Copyright (C) 2012 - Maria Christopoulou
 - Copyright (C) 2010 - 2011 - INRIA - Michael Baudin

--- a/doc/rsm.rst
+++ b/doc/rsm.rst
@@ -11,12 +11,13 @@ be described:
 
 - :ref:`Box-Behnken <box_behnken>`
 - :ref:`Central Composite <central_composite>`
+- :ref:`Doehlert Design <doehlert_design>`
 
 .. hint::
    All available designs can be accessed after a simple import statement::
 
     >>> from pyDOE3 import *
-    
+
 .. index:: Box-Behnken
 
 .. _box_behnken:
@@ -56,7 +57,7 @@ The default 3-factor Box-Behnken design::
            [ 0.,  0.,  0.],
            [ 0.,  0.,  0.],
            [ 0.,  0.,  0.]])
-    
+
 A customized design with four factors, but only a single center point::
 
     >>> bbdesign(4, center=1)
@@ -167,6 +168,66 @@ isn't variability so we only need a single center point::
            [ 0.        ,  0.        ,  1.        ],
            [ 0.        ,  0.        ,  0.        ]])
 
+.. index:: Doehlert Design
+
+.. _doehlert_design:
+
+Doehlert Design (``doehlert_shell_design``, ``doehlert_simplex_design``)
+========================================================================
+
+An alternative and very useful design for second-order models is the **uniform shell design** proposed by Doehlert in 1970 [Doehlert1970]_.  
+Doehlert designs are especially advantageous when optimizing multiple variables, requiring fewer experiments than central composite designs, while providing efficient and uniform coverage of the experimental domain.
+
+The Doehlert design defines a **spherical experimental domain** and emphasizes **uniform space filling**. Although it is not orthogonal or rotatable, it is generally sufficient for practical applications.
+
+For two variables, the Doehlert design consists of a center point and six points forming a regular hexagon, situated on a circle.
+
+The total number of experiments is given by:
+
+.. math::
+
+   N = k^2 + k + C_0
+
+where
+
+- :math:`k` = number of factors (variables)
+- :math:`C_0` = number of center points
+
+Two implementations are included:
+
+- ``doehlert_shell_design``: uses a shell-based spherical approach with optional center points.
+- ``doehlert_simplex_design``: uses a simplex-based method to uniformly fill the design space.
+
+Examples
+--------
+
+Create a Doehlert design with 3 factors and 1 center point using the shell approach::
+
+    >>> doehlert_shell_design(3, num_center_points=1)
+    array([[ 0.        ,  0.        ,  0.        ],
+           [ 1.        ,  0.        ,  0.        ],
+           [-0.5       ,  0.8660254 ,  0.        ],
+           [-0.5       , -0.8660254 ,  0.        ],
+           [ 0.8660254 ,  0.5       ,  0.        ],
+           [ 0.8660254 , -0.5       ,  0.        ],
+           ... ])
+
+Create a Doehlert design using the simplex approach for 3 factors::
+
+    >>> doehlert_simplex_design(3)
+    array([[ 0.       ,  0.        , 0.        ],
+           [ 1.       ,  0.        , 0.        ],
+           [ 0.       ,  0.8660254 , 0.        ],
+           [ 0.       ,  0.5       , 0.81649658],
+           [-1.       ,  0.        , 0.        ],
+           [ 0.       , -0.8660254 , 0.        ],
+           ... ])
+
+.. note::
+   Doehlert designs are recommended for response surface modeling when good space coverage and fewer experimental runs are desired.
+
+.. [Doehlert1970] Doehlert, David H. 1970. “Uniform Shell Designs.” *Applied Statistics* 19 (3): 231. https://doi.org/10.2307/2346327
+
 .. index:: Response Surface Designs Support
 
 More Information
@@ -177,6 +238,7 @@ consult the following articles on Wikipedia:
 
 - `Box-Behnken designs`_
 - `Central composite designs`_
+- `Doehlert design`_
 
 There is also a wealth of information on the `NIST`_ website about the
 various design matrices that can be created as well as detailed information
@@ -187,4 +249,5 @@ Any questions, comments, bug-fixes, etc. can be forwarded to the `author`_.
 .. _author: mailto:tisimst@gmail.com
 .. _Box-Behnken designs: http://en.wikipedia.org/wiki/Box-Behnken_design
 .. _Central composite designs: http://en.wikipedia.org/wiki/Central_composite_design
+.. _Doehlert design: https://academic.oup.com/jrsssc/article/19/3/231/6882590
 .. _NIST: http://www.itl.nist.gov/div898/handbook/pri/pri.htm

--- a/pyDOE3/__init__.py
+++ b/pyDOE3/__init__.py
@@ -44,6 +44,7 @@ from pyDOE3.doe_fold import fold
 from pyDOE3.doe_plackett_burman import pbdesign
 from pyDOE3.var_regression_matrix import var_regression_matrix
 from pyDOE3.doe_gsd import gsd
+from pyDOE3.doe_doehlert import doehlert_shell_design, doehlert_simplex_design
 
 __all__ = [
     "bbdesign",
@@ -65,6 +66,8 @@ __all__ = [
     "compute_snr",
     "list_orthogonal_arrays",
     "get_orthogonal_array",
+    "doehlert_shell_design",
+    "doehlert_simplex_design",
 ]
 
 from ._version import __version__  # noqa

--- a/pyDOE3/doe_doehlert.py
+++ b/pyDOE3/doe_doehlert.py
@@ -1,0 +1,128 @@
+"""
+This module implements the Doehlert experimental design.
+
+An alternative and very useful design for fitting second-order models
+is the uniform shell design proposed by Doehlert in 1970 (Doehlert 1970).
+Doehlert designs are particularly advantageous for optimizing multiple variables,
+offering a more efficient alternative to central composite designs. They require
+fewer experimental runs while maintaining flexibility to explore the experimental
+domain effectively.
+
+The Doehlert design defines a spherical experimental domain and emphasizes uniform
+space filling. Although the resulting matrix is neither orthogonal nor rotatable,
+its variance properties are generally acceptable and do not compromise its
+effectiveness in practical applications.
+
+References
+----------
+Doehlert, David H. 1970. “Uniform Shell Designs.” *Applied Statistics* 19 (3): 231.
+https://doi.org/10.2307/2346327
+
+Implementation of simplex design (`version 1.0.0`, 11 July 2015) by Moritz von Stosch
+https://www.mathworks.com/matlabcentral/fileexchange/54048-doehlert-design
+"""
+
+import numpy as np
+
+
+__all__ = ["doehlert_shell_design", "doehlert_simplex_design"]
+
+
+def doehlert_shell_design(num_factors, num_center_points=1):
+    """
+    Generate a Doehlert design matrix for a given number of factors using a shell approach.
+
+    Parameters
+    ----------
+    num_factors : int
+        Number of factors (variables).
+    num_center_points : int, optional
+        Number of center (replicate) points. Default is 1.
+
+    Returns
+    -------
+    np.ndarray
+        Design matrix of shape (N, num_factors), where
+
+        $$N = k^2 + k + C$$
+
+        with
+        - $$k$$ the number of factors,
+        - $$C$$ the number of center points.
+
+    Notes
+    -----
+    This function implements the "uniform shell" approach originally proposed by
+    Doehlert (1970), which allows for adding shells of points around the center.
+
+    References
+    ----------
+    Doehlert, David H. 1970. “Uniform Shell Designs.” *Applied Statistics* 19 (3): 231.
+    https://doi.org/10.2307/2346327
+    """
+    if num_factors < 1:
+        raise ValueError("Number of factors must be at least 1.")
+
+    # Start with center points
+    design_points = [np.zeros(num_factors) for _ in range(num_center_points)]
+
+    # Add shells progressively
+    for shell_index in range(1, num_factors + 1):
+        num_shell_points = shell_index + 1
+        angles = np.linspace(0, 2 * np.pi, num_shell_points, endpoint=False)
+        for angle in angles:
+            point = np.zeros(num_factors)
+            radius = np.sqrt(shell_index / num_factors)
+            point[0] = radius * np.cos(angle)
+            point[1] = radius * np.sin(angle)
+            design_points.append(point)
+
+    return np.array(design_points)
+
+
+def doehlert_simplex_design(num_factors):
+    """
+    Generate a Doehlert design matrix using a simplex-based approach.
+
+    Parameters
+    ----------
+    num_factors : int
+        Number of factors included in the design.
+
+    Returns
+    -------
+    np.ndarray
+        Design matrix with experiments at different coded levels.
+        The design matrix contains
+
+        $$ (k+1) + k \times (k+1 - 1) = k^2 + k + 1 $$
+
+        points, where $$k$$ is the number of factors.
+
+    Notes
+    -----
+    The simplex approach allows for uniform exploration of the design space.
+    It is inspired by the implementation by Moritz von Stosch (2015).
+
+    References
+    ----------
+    Implementation of simplex design (`version 1.0.0`, 11 July 2015) by Moritz von Stosch
+    https://www.mathworks.com/matlabcentral/fileexchange/54048-doehlert-design
+    """
+    simplex_matrix = np.zeros((num_factors + 1, num_factors))
+
+    for i in range(1, num_factors + 1):
+        for j in range(1, i + 1):
+            if j == i:
+                simplex_matrix[i, j - 1] = np.sqrt(i + 1) / np.sqrt(2 * i)
+            else:
+                simplex_matrix[i, i - j] = 1 / np.sqrt(2 * (i - (j - 1)) * (i - j))
+
+    extra_points = []
+    for i in range(num_factors + 1):
+        for j in list(range(1, i)) + list(range(i + 1, num_factors + 1)):
+            point = simplex_matrix[i, :] - simplex_matrix[j, :]
+            extra_points.append(point)
+
+    full_matrix = np.vstack([simplex_matrix, extra_points])
+    return full_matrix

--- a/tests/test_doehlert.py
+++ b/tests/test_doehlert.py
@@ -1,0 +1,45 @@
+import unittest
+import numpy as np
+from pyDOE3 import doehlert_shell_design, doehlert_simplex_design
+
+
+class TestDoehlertDesign(unittest.TestCase):
+    def test_shell_design_with_2_factors(self):
+        actual = doehlert_shell_design(2, num_center_points=1)
+
+        expected = np.array(
+            [
+                [0.0, 0.0],  # center
+                [np.sqrt(2) / 2, 0.0],  # shell 1, point 1
+                [-np.sqrt(2) / 2, 0.0],  # shell 1, point 2
+                [1.0, 0.0],  # shell 2, point 1
+                [-0.5, np.sqrt(3) / 2],  # shell 2, point 2
+                [-0.5, -np.sqrt(3) / 2],  # shell 2, point 3
+            ]
+        )
+
+        np.testing.assert_allclose(actual, expected, atol=1e-6)
+        self.assertEqual(actual.shape[1], 2)
+
+    def test_simplex_design_with_2_factors(self):
+        actual = doehlert_simplex_design(2)
+
+        expected = np.array(
+            [
+                [0.0, 0.0],  # center
+                [1.0, 0.0],
+                [0.0, np.sqrt(3) / 2],
+                [-1.0, 0.0],
+                [0.0, -np.sqrt(3) / 2],
+                [1.0, -np.sqrt(3) / 2],
+                [-1.0, np.sqrt(3) / 2],
+            ]
+        )
+
+        np.testing.assert_allclose(actual, expected, atol=1e-6)
+
+        self.assertEqual(actual.shape, (7, 2))
+        self.assertEqual(actual.shape[1], 2)
+
+        self.assertFalse(np.any(np.isnan(actual)))
+        self.assertFalse(np.any(np.isinf(actual)))

--- a/tests/test_factorial.py
+++ b/tests/test_factorial.py
@@ -100,7 +100,6 @@ class TestFactorial(unittest.TestCase):
             [1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
         ]
         actual = fracfact_by_res(6, 3)
-        print(actual)
         np.testing.assert_allclose(actual, expected)
 
     def test_issue_9(self):


### PR DESCRIPTION
## Add Doehlert Design Support (Shell & Simplex)

Adds support for Doehlert experimental designs (#22), including:
- `doehlert_shell_design`: shell-based uniform design
- `doehlert_simplex_design`: simplex-based design

Provides efficient, space-filling alternatives for response surface experiments with fewer runs.

References:
- Doehlert (1970). "Uniform Shell Designs." *Applied Statistics* 19(3): 231. [Link](https://www.jstor.org/stable/2346327)
